### PR TITLE
Updates dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
This config wasn't working because "yarn" is not a valid package ecosystem, https://github.com/figment-networks/wallet-tutorial/runs/10234231103. It needs to be "npm" per the docs, https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-dependabotyml